### PR TITLE
Déplacement des informations d'authentication de Access.cs vers App.config

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -13,4 +13,8 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+	<connectionStrings>
+		<add name="mediatekdocuments.Properties.Settings.mediatek86AuthenticationString"
+            connectionString="admin:adminpwd" />
+    </connectionStrings>
 </configuration>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 
 namespace MediaTekDocuments.dal
 {
@@ -17,6 +18,10 @@ namespace MediaTekDocuments.dal
         /// adresse de l'API
         /// </summary>
         private static readonly string uriApi = "http://localhost/rest_mediatekdocuments/";
+        /// <summary>
+        /// informations de connexion récupérées depuis App.config
+        /// </summary>
+        private static readonly string authenticationString = "mediatekdocuments.Properties.Settings.mediatek86AuthenticationString";
         /// <summary>
         /// instance unique de la classe
         /// </summary>
@@ -48,11 +53,9 @@ namespace MediaTekDocuments.dal
         /// </summary>
         private Access()
         {
-            String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
-                api = ApiRest.GetInstance(uriApi, authenticationString);
+                api = ApiRest.GetInstance(uriApi, GetConnectionStringByName(authenticationString));
             }
             catch (Exception e)
             {
@@ -72,6 +75,20 @@ namespace MediaTekDocuments.dal
                 instance = new Access();
             }
             return instance;
+        }
+
+        /// <summary>
+        /// Récupération de la chaîne de connexion
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        static string GetConnectionStringByName(string name)
+        {
+            string returnValue = null;
+            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings[name];
+            if (settings != null)
+                returnValue = settings.ConnectionString;
+            return returnValue;
         }
 
         /// <summary>

--- a/MediaTekDocuments/manager/ApiRest.cs
+++ b/MediaTekDocuments/manager/ApiRest.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Configuration;
 using System.Net.Http;
-using Newtonsoft.Json.Linq;
 
 namespace MediaTekDocuments.manager
 {


### PR DESCRIPTION
Les informations d'authentification sont stockées dans App.config plutôt que dans Access.cs